### PR TITLE
feat: lavalink v4 (#158)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,10 +204,8 @@ console.log(shoukaku.getIdealNode());
  Option | Type | Description
 --------|------|------------
 resume | boolean | Whether to resume a connection on disconnect to Lavalink (Server Side) (Note: DOES NOT RESUME WHEN THE LAVALINK SERVER DIES) |
-resumeKey | string | Resume key for Lavalink |
 resumeTimeout | number | Timeout before resuming a connection **in seconds** |
 resumeByLibrary | boolean | Whether to resume the players by doing it in the library side (Client Side) (Note: TRIES TO RESUME REGARDLESS OF WHAT HAPPENED ON A LAVALINK SERVER) |
-alwaysSendResumeKey | boolean | Disables the first time initialization tracking of nodes, and just sends the resume key always (Note: Useful for people who save their players to redis and wants to resume sessions even at first boot) |
 reconnectTries | number | Number of times to try and reconnect to Lavalink before giving up |
 reconnectInterval | number | Timeout before trying to reconnect **in seconds** |
 restTimeout | number | Time to wait for a response from the Lavalink REST API before giving up **in seconds** |

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -25,16 +25,14 @@ export enum OPCodes {
 }
 
 export enum Versions {
-    REST_VERSION = 3,
-    WEBSOCKET_VERSION = 3
+    REST_VERSION = 4,
+    WEBSOCKET_VERSION = 4
 }
 
 export const ShoukakuDefaults: ShoukakuOptions = {
     resume: false,
-    resumeKey: `Shoukaku@${Info.version}(${Info.repository.url})`,
     resumeTimeout: 30,
     resumeByLibrary: false,
-    alwaysSendResumeKey: false,
     reconnectTries: 3,
     reconnectInterval: 5,
     restTimeout: 60,

--- a/src/Shoukaku.ts
+++ b/src/Shoukaku.ts
@@ -47,10 +47,6 @@ export interface ShoukakuOptions {
      */
     resume?: boolean;
     /**
-     * Resume key for Lavalink
-     */
-    resumeKey?: string;
-    /**
      * Time to wait before lavalink starts to destroy the players of the disconnected client
      */
     resumeTimeout?: number;
@@ -58,10 +54,6 @@ export interface ShoukakuOptions {
      * Whether to resume the players by doing it in the library side (Client Side) (Note: TRIES TO RESUME REGARDLESS OF WHAT HAPPENED ON A LAVALINK SERVER)
      */
     resumeByLibrary?: boolean;
-    /**
-     * Disables the first time initialization tracking of nodes, and just sends the resume key always (Note: Useful for people who save their players to redis and wants to resume sessions even at first boot)
-     */
-    alwaysSendResumeKey?: boolean;
     /**
      * Number of times to try and reconnect to Lavalink before giving up
      */
@@ -103,10 +95,8 @@ export interface VoiceChannelOptions {
 
 export interface MergedShoukakuOptions {
     resume: boolean;
-    resumeKey: string;
     resumeTimeout: number;
     resumeByLibrary: boolean;
-    alwaysSendResumeKey: boolean;
     reconnectTries: number;
     reconnectInterval: number;
     restTimeout: number;
@@ -197,10 +187,8 @@ export class Shoukaku extends EventEmitter {
      * @param nodes An array that conforms to the NodeOption type that specifies nodes to connect to
      * @param options Options to pass to create this Shoukaku instance
      * @param options.resume Whether to resume a connection on disconnect to Lavalink (Server Side) (Note: DOES NOT RESUME WHEN THE LAVALINK SERVER DIES)
-     * @param options.resumeKey Resume key for Lavalink
      * @param options.resumeTimeout Time to wait before lavalink starts to destroy the players of the disconnected client
      * @param options.resumeByLibrary Whether to resume the players by doing it in the library side (Client Side) (Note: TRIES TO RESUME REGARDLESS OF WHAT HAPPENED ON A LAVALINK SERVER)
-     * @param options.alwaysSendResumeKey Disables the first time initialization tracking of nodes, and just sends the resume key always (Note: Useful for people who save their players to redis and wants to resume sessions even at first boot)
      * @param options.reconnectTries Number of times to try and reconnect to Lavalink before giving up
      * @param options.reconnectInterval Timeout before trying to reconnect
      * @param options.restTimeout Time to wait for a response from the Lavalink REST API before giving up

--- a/src/node/Rest.ts
+++ b/src/node/Rest.ts
@@ -1,9 +1,15 @@
 import { Node, NodeStats } from './Node';
 import { NodeOption } from '../Shoukaku';
 import { Versions } from '../Constants';
-import { FilterOptions } from '../guild/Player';
+import { Exception, FilterOptions } from '../guild/Player';
 
-export type LoadType = 'TRACK_LOADED' | 'PLAYLIST_LOADED' | 'SEARCH_RESULT' | 'NO_MATCHES' | 'LOAD_FAILED';
+export enum LoadType {
+    TRACK = 'track',
+    PLAYLIST = 'playlist',
+    SEARCH = 'search',
+    EMPTY = 'empty',
+    ERROR = 'error'
+}
 
 interface FetchOptions {
     endpoint: string;
@@ -17,8 +23,6 @@ interface FetchOptions {
 }
 
 export interface Track {
-    /** @deprecated */
-    track: string;
     encoded: string;
     info: {
         identifier: string;
@@ -29,18 +33,46 @@ export interface Track {
         position: number;
         title: string;
         uri?: string;
+        artworkUrl?: string;
+        isrc?: string;
         sourceName: string;
+    }
+    pluginInfo: object;
+}
+
+export interface TrackLoadResult {
+    loadType: LoadType.TRACK;
+    data: Track;
+}
+
+export interface PlaylistLoadResult {
+    loadType: LoadType.PLAYLIST;
+    data: {
+        info: {
+            name: string;
+            selectedTrack: number;
+        }
+        pluginInfo: object;
+        tracks: Track[];
     }
 }
 
-export interface LavalinkResponse {
-    loadType: LoadType;
-    playlistInfo: {
-        name?: string;
-        selectedTrack?: number;
-    }
-    tracks: Track[]
+export interface SearchLoadResult {
+    loadType: LoadType.SEARCH;
+    data: Track[];
 }
+
+export interface EmptyLoadResult {
+    loadType: LoadType.EMPTY;
+    data: {};
+}
+
+export interface ErrorLoadResult {
+    loadType: LoadType.ERROR;
+    data: Exception;
+}
+
+export type LavalinkResponse = TrackLoadResult | PlaylistLoadResult | SearchLoadResult | EmptyLoadResult | ErrorLoadResult;
 
 export interface Address {
     address: string;
@@ -233,18 +265,18 @@ export class Rest {
     }
 
     /**
-     * Updates the session with a resuming key and timeout
-     * @param resumingKey Resuming key to set
+     * Updates the session with a resume boolean and timeout
+     * @param resuming Whether resuming is enabled for this session or not
      * @param timeout Timeout to wait for resuming
      * @returns Promise that resolves to a Lavalink player
      */
-    public updateSession(resumingKey?: string, timeout?: number): Promise<SessionInfo | undefined> {
+    public updateSession(resuming?: boolean, timeout?: number): Promise<SessionInfo | undefined> {
         const options = {
             endpoint: `/sessions/${this.sessionId}`,
             options: {
                 method: 'PATCH',
                 headers: { 'Content-Type': 'application/json' },
-                body: { resumingKey, timeout }
+                body: { resuming, timeout }
             }
         };
         return this.fetch(options);


### PR DESCRIPTION
* feat: lavalink v4

* revert from node16 to es2020

* fix: remove alwaysSendSessionId needs a better reimplementation

* fix: get session id from this.sessionId

* fix: remove session ID from user input

* fix: remove non-null assertion operator



* fix: use session id in resumable headers



* fix: lavalink v4 load types



* feat: use enums for load types



---------